### PR TITLE
Issue #7: Add retries on busy pipe instances

### DIFF
--- a/npiperelay.go
+++ b/npiperelay.go
@@ -36,6 +36,13 @@ func dialPipe(p string, poll bool) (*overlappedFile, error) {
 			time.Sleep(200 * time.Millisecond)
 			continue
 		}
+		if err.Error() == "All pipe instances are busy." {
+			if *verbose {
+				log.Printf("All pipe instances are busy. Waiting 200 milliseconds to retry")
+			}
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
 		return nil, &os.PathError{Path: p, Op: "open", Err: err}
 	}
 }


### PR DESCRIPTION
I haven't found a more elegant way to check for this specific error. It looks like {syscall.Errno} does not offer more information than the error text.
https://golang.org/pkg/syscall/#Errno
https://golang.org/src/syscall/syscall_windows.go#L103